### PR TITLE
Fix issue with emojis before points

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,14 @@ slack.on('/fqscores', payload => {
 
           datastore.setEmoji(userAwardedPoints, pointsAwarded);
 
+          datastore.get(userAwardedPoints)
+            .catch(function(e){
+              console.log(e.type)
+              if(e.type = "DatastoreDataParsingException"){
+                datastore.setScore(userAwardedPoints, 0);
+              }
+            });
+
           slack.send(response_url, message).then(res => {
             console.log("Response sent to /fqscores slash command");
           }, reason => {


### PR DESCRIPTION
If a user is awarded an emoji but has no points their score will be
displayed as NaN in the scores table.

To prevent this, check the user's score when they are awarded an emoji.
If they do not yet have a score an rejected promise will be returned -
catch this and set their score to 0.